### PR TITLE
docs: add migration resources to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ It is public and open to contributions from the community.
 
 Please see the LICENSE file for contribution terms.
 Please see the CHANGELOG.md for details of recent updates.
+
+## Additional Migration Resources
+
+- [Kafka Migration Guide](https://www.confluent.io/resources/white-paper/migrate-from-kafka-to-confluent/)
+- [Migration Hub on Confluent Cloud](https://confluent.cloud/migration-hub)
+- [Talk to a migration expert from Confluent](https://meetings.salesloft.com/confluentinc/confluent-migration-assistance)


### PR DESCRIPTION
## Summary
- Adds an "Additional Migration Resources" section to the README with links to the Kafka Migration Guide, Migration Hub, and migration expert booking page
- Mirrors the same resources section added to the kcp repo

## Test plan
- [ ] Verify all three links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)